### PR TITLE
Virologist can open virus crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1013,7 +1013,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	cost = 2500
 	crate_type = /obj/structure/closet/crate/secure/medical
 	crate_name = "Virus sample crate"
-	access = access_cmo
+	access = access_virology
 	group = "Medical / Science"
 
 /datum/supply_pack/coolanttank


### PR DESCRIPTION
## Описание изменений
Доступ на ящике с вирусами изменён с cmo на virology
## Почему и что этот ПР улучшит
ВНЕЗАПНО в смене не всегда бывает кто-то могущий помочь вирусологу в открытии ящика. Сам застал пару таких смен.
## Авторство

## Чеинжлог
:cl: Wandermu
 - tweak: Вирусолог может открывать ящик карго с образцами вирусов.